### PR TITLE
addProperty() of BaciHelper.py raises the exception declared in both doctring and test

### DIFF
--- a/LGPL/CommonSoftware/acspy/idl/acspytest.midl
+++ b/LGPL/CommonSoftware/acspy/idl/acspytest.midl
@@ -76,7 +76,14 @@ module acspytest
 	void testAnything(in string compName, in string methodName, in string params);
 	};    
 
-    interface PyBaciTest : ACS::CharacteristicComponent
+
+    interface PyCommonBaciTest : ACS::CharacteristicComponent 
+    {
+	    readonly attribute ACS::ROdouble commonProp;
+    };
+
+
+    interface PyBaciTest : PyCommonBaciTest
 	{
 	MAKE_PROP(string);
 	MAKE_PROP(double);

--- a/LGPL/CommonSoftware/acspy/src/Makefile
+++ b/LGPL/CommonSoftware/acspy/src/Makefile
@@ -44,7 +44,7 @@ SCRIPTS   = acspyInteractiveContainer acsLoggingMonitor
 # 
 # IDL Files and flags
 # 
-IDL_FILES = 
+IDL_FILES = acspytest
 IDL_TAO_FLAGS =
 USER_IDL =
 

--- a/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
@@ -134,11 +134,15 @@ def addProperty(comp_ref,
     #------------------------------------------------------------------------------
     #if developer has not specified the property's type
     if prop_type == "":
-        # Retrieve the property type from the module information
-        newmod = __import__(modarray[1], globals(), locals(), modarray[2])
-        prop_ifr_name = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][1]
-        prop_type = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][2]
-
+        try:
+            # Retrieve the property type from the module information
+            newmod = __import__(modarray[1], globals(), locals(), modarray[2])
+            prop_ifr_name = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][1]
+            prop_type = nemod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][2]
+        except KeyError, ex:
+            raise CannotGetComponentExImpl(
+                    'The type of the property `%s` cannot be determined' 
+                    %prop_name )
     #------------------------------------------------------------------------------
     #create the BACI property object and set it as a member of the component
     prop_py_name = "__" + prop_name + "Object"

--- a/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
@@ -137,9 +137,11 @@ def addProperty(comp_ref,
         try:
             # Retrieve the property type from the module information
             newmod = __import__(modarray[1], globals(), locals(), modarray[2])
-            prop_ifr_name = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][1]
-            prop_type = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][2]
-        except KeyError, ex:
+            component = getattr(newmod, modarray[2])
+            attribute = getattr(component, '_d__get_%s' %prop_name)
+            prop_ifr_name = attribute[1][0][1]
+            prop_type = attribute[1][0][2]
+        except AttributeError, ex:
             raise CannotGetComponentExImpl(
                     'The type of the property `%s` cannot be determined' 
                     %prop_name )

--- a/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/src/Acspy/Util/BaciHelper.py
@@ -138,7 +138,7 @@ def addProperty(comp_ref,
             # Retrieve the property type from the module information
             newmod = __import__(modarray[1], globals(), locals(), modarray[2])
             prop_ifr_name = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][1]
-            prop_type = nemod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][2]
+            prop_type = newmod.__dict__[modarray[2]].__dict__['_d__get_'+prop_name][1][0][2]
         except KeyError, ex:
             raise CannotGetComponentExImpl(
                     'The type of the property `%s` cannot be determined' 
@@ -147,7 +147,7 @@ def addProperty(comp_ref,
     #create the BACI property object and set it as a member of the component
     prop_py_name = "__" + prop_name + "Object"
     prop_corba_name = "__" + prop_name + "CORBAObject"
-    
+
     #get the class implementation for the BACI property
     if prop_type == "ROstringSeq":
         prop_class = ROstringSeq

--- a/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
@@ -53,8 +53,9 @@ class AddPropertyCheck(unittest.TestCase):
         self.assertEqual(None, BaciHelper.IFR.lookup_id("Foo"))
 
     def testFailedIFRLookup(self):
-        """Correct exception thrown when Component not found."""
-        self.assertRaises(CannotGetComponentExImpl, BaciHelper.addProperty, self.victim, "Foo")
+        """Raise CannotGetComponentExImpl if it cannot get the property type"""
+        self.assertRaises(CannotGetComponentExImpl, BaciHelper.addProperty, 
+                          self.victim, "Foo")
 
 if __name__ == "__main__":
     unittest.main()

--- a/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
@@ -66,8 +66,8 @@ class AddPropertyCheck(unittest.TestCase):
         """Ensure it adds a property defined in the IDL interface"""
         BaciHelper.addProperty(self.victim, 'doubleROProp')
 
-    def testUserDefinedEnum(self):
-        """Fooo"""
+    def testAddUserDefinedEnumProperty(self):
+        """Ensure it adds a defined enum property"""
         BaciHelper.addProperty(self.victim, 'blarROProp')
 
 

--- a/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
@@ -70,15 +70,18 @@ class AddPropertyCheck(unittest.TestCase):
         """Ensure it adds a defined enum property"""
         BaciHelper.addProperty(self.victim, 'blarROProp')
 
+    def testInheritedProperty(self):
+        """Ensure it can look-up a property inherited from a base class"""
+        # The property commonProp is defined in the PyCommonBaciTest IDL 
+        # interface, and PyBaciTest interface inherits from PyCommonBaciTest
+        BaciHelper.addProperty(self.victim, 'commonProp')
+
 
 class PyBaciTestImpl(PyBaciTest, cc, services, lcycle):
 
     def __init__(self):
         cc.__init__(self)
         services.__init__(self)
-
-    def initialize(self):
-        addProperty(self, 'foo', devio_ref=DummyDevIO())
 
 
 class DummyDevIO(DevIO):

--- a/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
+++ b/LGPL/CommonSoftware/acspycommon/test/acspyTestUnitBaciHelper.py
@@ -30,20 +30,25 @@ __revision__ = "$Id: acspyTestUnitBaciHelper.py,v 1.1.1.1 2012/03/07 17:40:45 ac
 import unittest
 import mock
 #--ACS IMPORTS____-------------------------------------------------------------
-import acspytest__POA
 import Acspy.Util.BaciHelper as BaciHelper
-from maciErrTypeImpl      import CannotGetComponentExImpl
+from acspytest__POA import PyBaciTest
+from maciErrTypeImpl import CannotGetComponentExImpl
+from Acspy.Servants.CharacteristicComponent import CharacteristicComponent as cc
+from Acspy.Servants.ContainerServices import ContainerServices as services
+from Acspy.Servants.ComponentLifecycle import ComponentLifecycle as lcycle
+from ACSImpl.DevIO import DevIO
+
+
 #------------------------------------------------------------------------------
 
 class AddPropertyCheck(unittest.TestCase):
     """Tests of the addProperty() method."""
 
     def setUp(self):
-        mockIFR = mock.Mock( {"lookup_id" : None } )
+        mockIFR = mock.Mock({"lookup_id" : None })
         self.IFR = BaciHelper.IFR
         BaciHelper.IFR = mockIFR
-        self.victim = acspytest__POA.PyBaciTest()
-
+        self.victim = PyBaciTestImpl()
 
     def tearDown(self):
         BaciHelper.IFR = self.IFR
@@ -57,9 +62,39 @@ class AddPropertyCheck(unittest.TestCase):
         self.assertRaises(CannotGetComponentExImpl, BaciHelper.addProperty, 
                           self.victim, "Foo")
 
+    def testAddIDLDefinedProperty(self):
+        """Ensure it adds a property defined in the IDL interface"""
+        BaciHelper.addProperty(self.victim, 'doubleROProp')
+
+    def testUserDefinedEnum(self):
+        """Fooo"""
+        BaciHelper.addProperty(self.victim, 'blarROProp')
+
+
+class PyBaciTestImpl(PyBaciTest, cc, services, lcycle):
+
+    def __init__(self):
+        cc.__init__(self)
+        services.__init__(self)
+
+    def initialize(self):
+        addProperty(self, 'foo', devio_ref=DummyDevIO())
+
+
+class DummyDevIO(DevIO):
+
+    def __init__(self, device, value=0):
+        DevIO.__init__(self, value)
+
+    def read(self):
+        return self.value
+
+    def write(self, value):
+        self.value = value 
+
+
 if __name__ == "__main__":
     unittest.main()
-
 
 
 #


### PR DESCRIPTION
In the ``BaciHelper`` python module the ``addProperty()`` docstring says that it *Raises: CannotGetComponentExImpl if real type of BACI property cannot be determined*. That exception was not raised and that's why  the related test ``AddPropertyCheck.testFailedIFRLookup()`` did not pass. Now the code is fixed and the test passes. I also changed the test docstring in order to clarify the purpose of the test